### PR TITLE
feat: fallback image when application cannot load images from api

### DIFF
--- a/src/components/core/CastMember.tsx
+++ b/src/components/core/CastMember.tsx
@@ -11,7 +11,7 @@ const CastMember = ({ person }: CastMemberProps) => {
 		<div className="text-center">
 			<div className="w-full aspect-square bg-gray-800 rounded-full flex items-center justify-center mb-2">
 				<ImageWithFallback
-					src={person?.profile_path}
+					src={person?.profile_path || ""}
 					alt={person?.name}
 					width={100}
 					height={100}

--- a/src/components/core/CastMember.tsx
+++ b/src/components/core/CastMember.tsx
@@ -1,6 +1,6 @@
 import { CastMember as CastMemberType } from "@/src/interfaces/index";
 import { User } from "lucide-react";
-import Image from "next/image";
+import ImageWithFallback from "./ImageWithFallback";
 
 interface CastMemberProps {
 	person: CastMemberType;
@@ -10,17 +10,14 @@ const CastMember = ({ person }: CastMemberProps) => {
 	return (
 		<div className="text-center">
 			<div className="w-full aspect-square bg-gray-800 rounded-full flex items-center justify-center mb-2">
-				{person?.profile_path ? (
-					<Image
-						src={person?.profile_path}
-						alt={person?.name}
-						width={100}
-						height={100}
-						className="w-full h-full object-cover rounded-full"
-					/>
-				) : (
-					<User className="w-12 h-12 text-gray-600" />
-				)}
+				<ImageWithFallback
+					src={person?.profile_path}
+					alt={person?.name}
+					width={100}
+					height={100}
+					className="w-full h-full object-cover rounded-full"
+					fallback={<User className="w-12 h-12 text-gray-600" />}
+				/>
 			</div>
 			<h3 className="font-medium text-sm">{person?.name}</h3>
 			<p className="text-gray-400 text-xs">{person?.character}</p>

--- a/src/components/core/ImageWithFallback.tsx
+++ b/src/components/core/ImageWithFallback.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React, { useState } from "react";
+import Image, { ImageProps } from "next/image";
+
+interface ImageWithFallbackProps extends ImageProps {
+	fallback: React.ReactNode;
+}
+
+const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({
+	src,
+	fallback,
+	...rest
+}) => {
+	const [hasError, setHasError] = useState(false);
+
+	return hasError || !src ? (
+		<>{fallback}</>
+	) : (
+		<Image src={src} {...rest} onError={() => setHasError(true)} />
+	);
+};
+
+export default ImageWithFallback;

--- a/src/components/movies/MovieCard.tsx
+++ b/src/components/movies/MovieCard.tsx
@@ -7,6 +7,7 @@ import { Star } from "lucide-react";
 import { useInView } from "react-intersection-observer";
 import { Movie } from "@/src/interfaces";
 import { motion } from "framer-motion";
+import ImageWithFallback from "../core/ImageWithFallback";
 
 interface MovieCardProps {
 	movie: Movie;
@@ -38,22 +39,21 @@ const MovieCard: React.FC<MovieCardProps> = ({
 			>
 				{/* movie poster */}
 				<div className="relative aspect-[2/3] overflow-hidden w-full sm:w-[300px]">
-					{movie?.poster_path ? (
-						<Image
-							src={movie?.poster_path}
-							alt={`${movie?.title} poster`}
-							className="w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-300"
-							width={500}
-							height={750}
-						/>
-					) : (
-						<div className="w-full h-full bg-gray-800 flex items-center justify-center">
-							<div className="text-center text-gray-400">
-								<div className="text-4xl mb-2">🎬</div>
-								<div className="text-sm px-4">No Image Available</div>
+					<ImageWithFallback
+						src={movie?.poster_path || ""}
+						alt={`${movie?.title} poster`}
+						className="w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-300"
+						width={500}
+						height={750}
+						fallback={
+							<div className="w-full h-full bg-gray-800 flex items-center justify-center">
+								<div className="text-center text-gray-400">
+									<div className="text-4xl mb-2">🎬</div>
+									<div className="text-sm px-4">No Image Available</div>
+								</div>
 							</div>
-						</div>
-					)}
+						}
+					/>
 					<div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-70 group-hover:opacity-90 transition-opacity"></div>
 
 					{/* rating */}

--- a/src/components/movies/MovieCard.tsx
+++ b/src/components/movies/MovieCard.tsx
@@ -38,13 +38,13 @@ const MovieCard: React.FC<MovieCardProps> = ({
 				data-testid={dataTestId}
 			>
 				{/* movie poster */}
-				<div className="relative aspect-[2/3] overflow-hidden w-full sm:w-[300px]">
+				<div className="relative aspect-[2/3] overflow-hidden w-full rounded-md">
 					<ImageWithFallback
 						src={movie?.poster_path || ""}
 						alt={`${movie?.title} poster`}
-						className="w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-300"
-						width={500}
-						height={750}
+						fill
+						sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+						className="object-cover transform group-hover:scale-105 transition-transform duration-300"
 						fallback={
 							<div className="w-full h-full bg-gray-800 flex items-center justify-center">
 								<div className="text-center text-gray-400">
@@ -54,7 +54,6 @@ const MovieCard: React.FC<MovieCardProps> = ({
 							</div>
 						}
 					/>
-					<div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-70 group-hover:opacity-90 transition-opacity"></div>
 
 					{/* rating */}
 					<div className="absolute top-2 left-2 flex items-center bg-black/60 rounded-full px-2 py-1 text-sm">

--- a/src/components/movies/MovieHero.tsx
+++ b/src/components/movies/MovieHero.tsx
@@ -1,8 +1,8 @@
 import { Play, Star, Clock } from "lucide-react";
-import Image from "next/image";
 import React from "react";
 import { Movie } from "@/src/interfaces";
 import AddToFavoritesBtn from "@/src/components/core/AddToFavoritesBtn";
+import ImageWithFallback from "@/src/components/core/ImageWithFallback";
 
 interface MovieHeroProps {
 	movie: Movie;
@@ -12,23 +12,22 @@ const MovieHero: React.FC<MovieHeroProps> = ({ movie }) => {
 	return (
 		<div className="relative">
 			<div className="absolute inset-0 h-[70vh]">
-				{movie?.backdrop_path ? (
-					<Image
-						src={movie?.backdrop_path}
-						alt={`${movie?.title} backdrop`}
-						className="w-full h-full object-cover"
-						width={1000}
-						height={1000}
-						priority
-					/>
-				) : (
-					<div className="w-full h-full bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center">
-						<div className="text-center text-gray-400">
-							<h2 className="text-2xl font-bold mb-2">{movie?.title}</h2>
-							<p className="text-sm">No backdrop available</p>
+				<ImageWithFallback
+					src={movie?.backdrop_path || ""}
+					alt={`${movie?.title} backdrop`}
+					className="w-full h-full object-cover"
+					width={1000}
+					height={1000}
+					priority
+					fallback={
+						<div className="w-full h-full bg-gradient-to-br from-gray-800 to-gray-900 flex items-center justify-center">
+							<div className="text-center text-gray-400">
+								<h2 className="text-2xl font-bold mb-2">{movie?.title}</h2>
+								<p className="text-sm">No backdrop available</p>
+							</div>
 						</div>
-					</div>
-				)}
+					}
+				/>
 				<div className="absolute inset-0 bg-gradient-to-t from-gray-950 to-gray-950/40"></div>
 			</div>
 


### PR DESCRIPTION
This pull request introduces a reusable `ImageWithFallback` component to handle image rendering with fallback options across the application. The changes replace direct usage of the `next/image` component with `ImageWithFallback` in several key components, improving error handling and user experience when images fail to load or are unavailable.

### Introduction of `ImageWithFallback` Component:
* [`src/components/core/ImageWithFallback.tsx`](diffhunk://#diff-730dab251decd9054520c8ba4668cb84c56585995f088542f01877e870198325R1-R24): Added a new reusable component `ImageWithFallback` that wraps the `next/image` component and provides a fallback UI when the image fails to load. It uses an `onError` handler and a `fallback` prop to display alternative content.

### Updates to Core Components:
* [`src/components/core/CastMember.tsx`](diffhunk://#diff-b5cf263f5c336587963ae65efbccbbd7cc41d5b5720d74f37a23d89b8486b571L3-R3): Replaced `next/image` with `ImageWithFallback` for rendering cast member profile images. Added a fallback icon (`User`) for cases where the profile image is unavailable. [[1]](diffhunk://#diff-b5cf263f5c336587963ae65efbccbbd7cc41d5b5720d74f37a23d89b8486b571L3-R3) [[2]](diffhunk://#diff-b5cf263f5c336587963ae65efbccbbd7cc41d5b5720d74f37a23d89b8486b571L13-L23)

### Updates to Movie-Related Components:
* [`src/components/movies/MovieCard.tsx`](diffhunk://#diff-c807092bac8c292a24b06f95f218a77beab2847056d317badb1f68996907f1c5R10): Updated the movie poster rendering to use `ImageWithFallback`, providing a fallback UI with a placeholder message and icon when the poster image is missing. [[1]](diffhunk://#diff-c807092bac8c292a24b06f95f218a77beab2847056d317badb1f68996907f1c5R10) [[2]](diffhunk://#diff-c807092bac8c292a24b06f95f218a77beab2847056d317badb1f68996907f1c5L40-R56)
* [`src/components/movies/MovieHero.tsx`](diffhunk://#diff-31525bdb46afdb4a0d2687a0178bc810b2b582b1d6d7ff31da6e91a04a52afeaL2-R5): Replaced `next/image` with `ImageWithFallback` for the movie backdrop image. Added a fallback UI with the movie title and a message for cases where the backdrop is unavailable. [[1]](diffhunk://#diff-31525bdb46afdb4a0d2687a0178bc810b2b582b1d6d7ff31da6e91a04a52afeaL2-R5) [[2]](diffhunk://#diff-31525bdb46afdb4a0d2687a0178bc810b2b582b1d6d7ff31da6e91a04a52afeaL15-R30)